### PR TITLE
Correct search term for Jetbrains Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ _On Your Jetbrains IDE_:
 - Open Settings/Preferences
 - Plugins
 - Marketplace
-- Search for "Tokyo Dark Theme"
+- Search for "Tokyo Night Dark Theme"
 - Install Plugin
 
 Copyright &copy; 2024-present [Junk F. Actory](https://github.com/junkfactory/tokyonight-jetbrains)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ _On Your Jetbrains IDE_:
 - Open Settings/Preferences
 - Plugins
 - Marketplace
-- Search for "TokyoDark Theme"
+- Search for "Tokyo Dark Theme"
 - Install Plugin
 
 Copyright &copy; 2024-present [Junk F. Actory](https://github.com/junkfactory/tokyonight-jetbrains)


### PR DESCRIPTION
Simple tweak that provides the correct search term for finding this theme in the [Jetbrains Marketplace](https://plugins.jetbrains.com/) or via Jetbrains software via `Settings -> Plugins -> Marketplace`. 

Screenshots demonstrating difference between search terms:

![2024-06-12_15-38](https://github.com/junkfactory/tokyonight-jetbrains/assets/85717231/b0c0aed4-48c6-40d3-8ec7-5108c8668240)

![2024-06-12_15-37](https://github.com/junkfactory/tokyonight-jetbrains/assets/85717231/5b23993b-5699-431c-8d94-1e86a7d90812)
