### PR TITLE
Make gitignored file names visible

### DIFF
--- a/src/main/resources/themes/TokyoDark.xml
+++ b/src/main/resources/themes/TokyoDark.xml
@@ -21,8 +21,8 @@
     <option name="ERROR_HINT" value="414868"></option>
     <option name="FILESTATUS_ADDED" value="73daca"></option>
     <option name="FILESTATUS_DELETED" value="f7768e"></option>
-    <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="2c2e40"></option>
-    <option name="FILESTATUS_IDEA_FILESTATUS_IGNORED" value="2c2e40"></option>
+    <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="5e658d"></option>
+    <option name="FILESTATUS_IDEA_FILESTATUS_IGNORED" value="5e658d"></option>
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="e0af68"></option>
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="e0af68"></option>
     <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="e0af68"></option>


### PR DESCRIPTION
![Demonstration of how when a file is gitignored, the name is very hard to read](https://github.com/user-attachments/assets/03c25327-aa2f-4ee4-8db3-77038ef22368)

Gitignored file names are basically invisible. In this PR, I increase the lightness of what I assume to be the corresponding colour, to a level that is still too dark to be accessible but possible to read.